### PR TITLE
docs: add note about $CI_SERVER_FQDN variable in GitLab CI/CD pipeline 

### DIFF
--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -38,6 +38,7 @@ You can also modify the `script` section to run different Qodo Merge commands, o
 
 Note that if your base branches are not protected, don't set the variables as `protected`, since the pipeline will not have access to them.
 
+> **Note**: The `$CI_SERVER_FQDN` variable is available starting from GitLab version 16.10. If you're using an earlier version, this variable will not be available. However, you can combine `$CI_SERVER_HOST` and `$CI_SERVER_PORT` to achieve the same result. Please ensure you're using a compatible version or adjust your configuration.
 
 
 ## Run a GitLab webhook server


### PR DESCRIPTION
This update adds a note to clarify the availability of the `$CI_SERVER_FQDN` variable, which was introduced in GitLab 16.10 ([docs](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)). Older GitLab versions may not have this variable, which could lead to potential configuration issues.

The change:
- Provides context for users about the `$CI_SERVER_FQDN` variable, helping to prevent confusion and troubleshooting delays for those on earlier GitLab versions.
- Adds guidance on how to achieve the same result on older versions by using `$CI_SERVER_HOST` and `$CI_SERVER_PORT` instead.